### PR TITLE
fix:  Adjustment of posting interval slack

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,10 @@
-name: Deploy
+name: Deploy News Bot
 
 on:
   push:
     branches: [ main ]
   schedule:
-    - cron: '0 */6 * * *'  # Every 6 hours
+    - cron: '0 4 * * *'  # 毎日13時（JST）に実行（UTC 4:00）
 
 jobs:
   deploy:
@@ -18,5 +18,7 @@ jobs:
         with:
           go-version: 1.24.1
 
-      - name: Create .env file
-        run: echo "SLACK_WEBHOOK_NEWS_DRONE_JP_CH_URL=${{ secrets.SLACK_WEBHOOK_NEWS_DRONE_JP_CH_URL }}" > .env
+      - name: Run news bot
+        env:
+          SLACK_WEBHOOK_NEWS_DRONE_JP_CH_URL: ${{ secrets.SLACK_WEBHOOK_NEWS_DRONE_JP_CH_URL }}
+        run: go run cmd/newsbot/main.go

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -3,34 +3,68 @@ package slack
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
-	"os"
+	"newsbot/internal/scraper"
+	"strings"
 )
 
 type SlackMessage struct {
 	Text string `json:"text"`
 }
 
-func SendToSlack(message string) {
-	webhookURL := os.Getenv("SLACK_WEBHOOK_NEWS_DRONE_JP_CH_URL")
-	if webhookURL == "" {
-		log.Println("Error: Slack Webhook URL is not set. Make sure it's configured in GitHub Secrets.")
-		return
-	}
-
+func SendToSlack(webhookURL string, message string) error {
 	payload, err := json.Marshal(SlackMessage{Text: message})
 	if err != nil {
-		log.Printf("Error marshalling JSON: %v", err)
-		return
+		return fmt.Errorf("error marshalling JSON: %v", err)
 	}
 
 	resp, err := http.Post(webhookURL, "application/json", bytes.NewBuffer(payload))
 	if err != nil {
-		log.Printf("Error sending Slack message: %v", err)
-		return
+		return fmt.Errorf("error sending Slack message: %v", err)
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("error: received non-200 response code: %d", resp.StatusCode)
+	}
+
 	log.Println("Slack message sent successfully!")
+	return nil
+}
+
+// PostArticlesToSlack 記事をSlackに投稿
+func PostArticlesToSlack(webhookURL string, articles []scraper.Article) error {
+	if len(articles) == 0 {
+		return fmt.Errorf("no articles to post")
+	}
+
+	// 各記事を個別に投稿
+	for _, article := range articles {
+		message := fmt.Sprintf("*%s*\n%s\n%s\n%s",
+			article.Title,
+			article.URL,
+			article.Summary,
+			article.Thumbnail)
+
+		if err := SendToSlack(webhookURL, message); err != nil {
+			log.Printf("Warning: Failed to post article '%s': %v", article.Title, err)
+			continue
+		}
+	}
+
+	// 記事一覧のサマリーを作成
+	var summary strings.Builder
+	summary.WriteString("*本日の記事一覧*\n")
+	for i, article := range articles {
+		summary.WriteString(fmt.Sprintf("%d. <%s|%s>\n", i+1, article.URL, article.Title))
+	}
+
+	// サマリーを投稿
+	if err := SendToSlack(webhookURL, summary.String()); err != nil {
+		return fmt.Errorf("failed to post summary: %v", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The News Bot is now scheduled to run daily at 4 AM UTC (1 PM JST) to deliver timely updates.
  - It now fetches and displays only today’s news articles with clear publication dates.

- **Improvements**
  - Enhanced Slack integration delivers a summarized update of news articles with improved error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->